### PR TITLE
delete disable_nojekyll

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -76,5 +76,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: master
-          disable_nojekyll: true
           cname: uzimaru.dev


### PR DESCRIPTION
The disable_nojekyll option is only for the Jekyll.
